### PR TITLE
chore(deps): prioritize Renovate managers via prPriority

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,7 @@
   "packageRules": [
     {
       "matchManagers": ["nuget"],
+      "prPriority": 5,
       "labels": ["dependency:nuget"],
       "semanticCommits": "enabled",
       "semanticCommitType": "chore",
@@ -40,6 +41,7 @@
     },
     {
       "matchManagers": ["github-actions"],
+      "prPriority": 10,
       "labels": ["dependency:actions"],
       "automerge": true,
       "semanticCommits": "enabled",
@@ -49,6 +51,7 @@
     },
     {
       "matchDatasources": ["docker", "custom.regex"],
+      "prPriority": -5,
       "labels": ["dependency:docker"],
       "semanticCommits": "enabled",
       "semanticCommitType": "chore",


### PR DESCRIPTION
## What

Adds `prPriority` values to the existing manager-scoped `packageRules` in `renovate.json` so Renovate processes dependency updates in a defined order:

| Priority | Scope | Rule |
|---:|---|---|
| `10` | GitHub Actions / pipeline templates | `matchManagers: ["github-actions"]` |
| `5` | NuGet packages | `matchManagers: ["nuget"]` |
| `0` (default) | Everything else | no rule needed — Renovate's default |
| `-5` | Docker images (`dockerfile` manager and the `custom.regex` manager for `/* dockerimage */` pins in `.cs` files) | `matchDatasources: ["docker", "custom.regex"]` |

## Why

When multiple updates are pending, Renovate creates and rebases PRs in `prPriority` order (higher first). This matters in combination with the `prConcurrentLimit` / `prHourlyLimit` limits inherited from `config:best-practices`: pipeline and tooling updates surface first, NuGet package updates second, and Docker image bumps last instead of competing for the same PR slots.

## Notes

- `prPriority` only affects **ordering**; it does not change which updates are created, grouped, or automerged.
- Managers not listed in `enabledManagers` are unaffected — they don't run at all.