### PR TITLE
chore(deps): streamline Renovate config and prioritize security updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,12 +4,17 @@
     "config:best-practices",
     ":disableDependencyDashboard",
     ":automergeMinor",
-    ":automergePatch",
     ":rebaseStalePrs"
   ],
   "ignorePresets": ["group:monorepos"],
-  "automergeType": "pr",
   "automergeStrategy": "squash",
+  "assignees": ["samtrion"],
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "prPriority": 20
+  },
   "enabledManagers": ["custom.regex", "dockerfile", "github-actions", "nuget"],
   "ignorePaths": [
     "**/node_modules/**",
@@ -34,29 +39,26 @@
       "matchManagers": ["nuget"],
       "prPriority": 5,
       "labels": ["dependency:nuget"],
-      "semanticCommits": "enabled",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
-      "assignees": ["samtrion"]
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["NetEvolve", "NetEvolve.*"],
+      "minimumReleaseAge": null
     },
     {
       "matchManagers": ["github-actions"],
       "prPriority": 10,
       "labels": ["dependency:actions"],
       "automerge": true,
-      "semanticCommits": "enabled",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "ci",
-      "assignees": ["samtrion"]
+      "semanticCommitScope": "ci"
     },
     {
       "matchDatasources": ["docker", "custom.regex"],
       "prPriority": -5,
       "labels": ["dependency:docker"],
-      "semanticCommits": "enabled",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "docker",
-      "assignees": ["samtrion"],
       "versioning": "loose"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -40,7 +40,7 @@
       "prPriority": 5,
       "labels": ["dependency:nuget"],
       "semanticCommitScope": "deps",
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "1 day"
     },
     {
       "matchManagers": ["nuget"],


### PR DESCRIPTION
Follow-up to #347.

## What

### Cleanup — no behavior change
- **Remove `:automergePatch`** — `:automergeMinor` already covers patch updates; in Renovate's semantics "minor" includes patch-level updates.
- **Remove `automergeType: "pr"`** — this is Renovate's default value.
- **Hoist repeated settings to the top level** — `assignees`, `semanticCommits: "enabled"`, and `semanticCommitType: "chore"` were duplicated across all three manager package rules. They now live once at the top level; the rules keep only what actually differs (`semanticCommitScope`, labels, versioning).

### Behavior changes
- **`osvVulnerabilityAlerts: true` + `vulnerabilityAlerts.prPriority: 20`** — Renovate now raises PRs for OSV-known vulnerabilities, and those PRs outrank everything else in the priority order introduced by #347 (actions 10 → nuget 5 → default 0 → docker -5). Longer term this could replace the Dependabot security-update workaround in `.github/dependabot.yml`.
- **`minimumReleaseAge: "1 day"` for NuGet** — new package versions must be at least 1 day old before Renovate proposes them. This protects against releases that get unpublished or immediately hotfixed, which matters here because minor/patch updates automerge. Vulnerability-alert PRs bypass this delay.
  - **Exemption for first-party packages**: `NetEvolve` / `NetEvolve.*` packages are excluded from the release-age requirement, so our own releases flow through without delay.
